### PR TITLE
Create configuration for Black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 80
+max-line-length = 79
 max-complexity = 16
 # B = bugbear
 # B9 = bugbear opinionated (incl line length)

--- a/.pylintrc
+++ b/.pylintrc
@@ -84,3 +84,7 @@ enable=anomalous-backslash-in-string,
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 output-format=colorized
 reports=no
+
+[FORMAT]
+
+max-line-length=79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 79
+target-version = ['py37']
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
This change makes sure Black obeys the PEP8 line length of 79
characters, and makes py37 the explicit target for consistency's sake.

@huguesdk 