### PR TITLE
Bump prettier and plugin-xml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,13 +43,13 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.1.2
+    rev: v2.4.1
     hooks:
       - id: prettier
         name: prettier + plugin-xml
         additional_dependencies:
-          - "prettier@2.1.2"
-          - "@prettier/plugin-xml@0.12.0"
+          - "prettier@2.4.1"
+          - "@prettier/plugin-xml@1.1.0"
         args:
           - --plugin=@prettier/plugin-xml
   #  - repo: https://github.com/pre-commit/mirrors-eslint


### PR DESCRIPTION
plugin-xml was broken on Fedora for me; zeroing all XML files on first
contact. Bumping the versions fixes this.
